### PR TITLE
Update comment about github-wiki-see wiki counts to be more ambiguous

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -24,7 +24,7 @@
 *://www.higithub.com/*
 *://openprojectrepo.com/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
-! At the moment, only about 1,200 GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
+! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.
 ! It's actually a helpful GitHub copycat.
 ! *://github-wiki-see.page/*


### PR DESCRIPTION
1,200 was the last number

3,300 is the more exact current number.

https://github.com/nelsonjchen/github-wiki-see-rs/issues/126

If the magnitude changes more, I can update it but let's just use this comment string for now.