### PR TITLE
Block golangissues.com as github copycat

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -23,6 +23,7 @@
 *://github.innominds.com/*
 *://www.higithub.com/*
 *://openprojectrepo.com/*
+*://golangissues.com/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
 ! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.


### PR DESCRIPTION
Example: https://golangissues.com/issues/1406036, just an out of date mirror of https://github.com/xvello/letsblockit/issues/67

Of course, the website serves google ads :)