### PR TITLE
Block gitmotion.com as github copycat

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -3,6 +3,7 @@
 *://bleepcoder.com/*
 *://githubja.com/*
 *://*.gitmemory.com/*
+*://*.gitmotion.com/*
 *://giters.com/*
 *://githubmemory.com/*
 *://*.wenyanet.com/*


### PR DESCRIPTION
Example:
https://gitmotion.com/rust/279590319/safe-api-for-constructing-enum-from-an-integer is mirroring https://github.com/rust-lang/rust/issues/46529

I'll give them credit for at least just showing the most helpful comment from github. But all the context is lost.