### PR TITLE
add helpex.vn

### DIFF
--- a/data/stackoverflow_copycats.txt
+++ b/data/stackoverflow_copycats.txt
@@ -235,3 +235,4 @@
 *://www.ringingliberty.com/*
 *://askandroidquestions.com/*
 *://tutorialmeta.com/*
+*://helpex.vn/*


### PR DESCRIPTION
copy & auto translation

source: https://stackoverflow.com/questions/63109987/nameerror-name-mysql-is-not-defined-after-setting-change-to-mysql

copied: https://helpex.vn/question/nameerror-name-mysql-khong-duoc-xac-dinh-sau-khi-thiet-lap-thay-doi-thanh-mysql-60a00ea1a941cd7a68ba9a84