### PR TITLE
add: stackallflow.com

### DIFF
--- a/data/stackoverflow_copycats.txt
+++ b/data/stackoverflow_copycats.txt
@@ -246,3 +246,4 @@
 *://dockerquestions.com/*
 *://angularquestions.com/*
 *://www.pythonfixing.com/*
+*://stackallflow.com/*


### PR DESCRIPTION
original URL: https://apple.stackexchange.com/questions/391147/is-it-possible-to-backup-via-time-machine-to-smb-behind-nat-on-non-standard-port
evidence: https://stackallflow.com/ask-different/mac-is-it-possible-to-backup-via-time-machine-to-smb-behind-nat-on-non-standard-ports/