### PR TITLE
add intelligentsystemsmonitoring.com

### DIFF
--- a/data/stackoverflow_copycats.txt
+++ b/data/stackoverflow_copycats.txt
@@ -248,3 +248,4 @@
 *://www.pythonfixing.com/*
 *://stackallflow.com/*
 *://nxtstage.net/*
+*://intelligentsystemsmonitoring.com/*


### PR DESCRIPTION
URL: https://intelligentsystemsmonitoring.com/community/nginx-cache-status-miss-even-after-adding-caching-2/
Evidence: https://serverfault.com/questions/827068/nginx-cache-status-miss-even-after-adding-caching