### PR TITLE
move codespot.com from npm to github copycats

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -65,6 +65,7 @@
 *://golangexample.com/*
 *://github.astrophel.org/*
 *://www.gitdetail.com/*
+*://codespots.com/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
 ! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.

--- a/data/npm_copycats.txt
+++ b/data/npm_copycats.txt
@@ -1,4 +1,3 @@
 *://npmmirror.com/*
 *://cnpmjs.org/*
 *://npm.io/*
-*://codespots.com/*


### PR DESCRIPTION
codespot.com contains github copycats, see for example https://codespots.com/library/item/3852 that is only at github (https://github.com/nihgwu/react-native-sudoku), and not at npm