### PR TITLE
data: add Wikipedia mirrors

### DIFF
--- a/data/wikipedia_copycats.txt
+++ b/data/wikipedia_copycats.txt
@@ -39,3 +39,12 @@
 *://static.hlt.bme.hu/*
 *://wikibrief.org/*
 *://second.wiki/*
+*://studymode.com/*
+*://liquisearch.com/*
+*://paperzz.com/*
+*://edufrogs.com/*
+*://patrickkidd3.typepad.com/*
+*://josehist.weebly.com/*
+*://primidi.com/*
+*://wn.com/*
+*://actingcollegeses.com/*


### PR DESCRIPTION
Original: https://en.wikipedia.org/wiki/First_five-year_plan (revision unknown)

Evidence(*): https://paperzz.com/doc/7738264/first-five-year-plan--soviet-union-

Notice the image to the right and its caption.
Fortunately it's unchanged in the original wikipedia article at the time of writing.
Based on this, further URLs were discovered.

URLs:

Query term/needle: "One of the primary objectives of Stalin's First Five-Year Plan was to build up the country's heavy industry."
DDG results:
  - https://www.studymode.com/essays/Stalin-5-Year-Plan-1777540.html
  - https://www.liquisearch.com/first_five-year_plan_soviet_union
  - https://paperzz.com/doc/7738264/first-five-year-plan--soviet-union-
  - https://edufrogs.com/stalin-5-year-plan-essay/
  - https://patrickkidd3.typepad.com/blog/food-and-drink/ (** obvious SEO spam)
  - http://josehist.weebly.com/industrialization-5-year-plans-1928-1941.html (** any link on this page yields a redirect suggestion)

Query term/needle: "The First Five-Year Plan, or 1st Five-Year Plan, of the Union of Soviet Socialist Republics (USSR) was a list of economic goals,"
DDG results:
  - https://www.primidi.com/first_five-year_plan_soviet_union

Query term/needle: "The First Five-Year Plan, or 1st Five-Year Plan, of the Union of Soviet Socialist Republics (USSR) was a list of economic goals, created by Joseph Stalin and based off his policy of Socialism in One Country, that was designed to strengthen the country's economy between 1928 and 1932."
Google results:
  - https://wn.com/First_Five-Year_Plan
  - https://actingcollegeses.com/library/acting-questions/read/61685-what-did-lil-wayne-mean-by-lasagna (** SEO spam)