### PR TITLE
add gitmemories.com to the filter

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -74,6 +74,7 @@
 *://pullanswer.com/*
 *://devpick.io/*
 *://opensourceagenda.com/*
+*://gitmemories.com/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
 ! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.


### PR DESCRIPTION
Evidence: https://gitmemories.com/zlib-ng/zlib-ng/issues/1323
Original: `https://github.com/zlib-ng/zlib-ng/issues/1323`