### PR TITLE
Fix syntax

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -24,7 +24,10 @@ def to_domain_attr(url):
         .lstrip(".")
 
 def to_domain_ublock(url):
-    return f"||{format_url(url)}^$all"
+    if "/" in url:
+        return f"||{format_url(url)}$all"
+    else:
+        return f"||{format_url(url)}^$all"
 
 def to_google(url):
     return f'google.*##.g:has(a[href*="{format_url(url)}"])'

--- a/src/generate.py
+++ b/src/generate.py
@@ -27,7 +27,7 @@ def to_domain_ublock(url):
     if "/" in url:
         return f"||{format_url(url)}$all"
     else:
-        return f"||{format_url(url)}^$all"
+        return f"||{format_url(to_domain_attr(url))}^$all"
 
 def to_google(url):
     return f'google.*##.g:has(a[href*="{format_url(url)}"])'

--- a/src/generate.py
+++ b/src/generate.py
@@ -24,7 +24,7 @@ def to_domain_attr(url):
         .lstrip(".")
 
 def to_domain_ublock(url):
-    return f"||{format_url(url)}$all"
+    return f"||{format_url(url)}^$all"
 
 def to_google(url):
     return f'google.*##.g:has(a[href*="{format_url(url)}"])'

--- a/src/generate.py
+++ b/src/generate.py
@@ -27,7 +27,7 @@ def to_domain_ublock(url):
     if "/" in url:
         return f"||{format_url(url)}$all"
     else:
-        return f"||{format_url(to_domain_attr(url))}^$all"
+        return f"||{format_url(url)}^$all"
 
 def to_google(url):
     return f'google.*##.g:has(a[href*="{format_url(url)}"])'


### PR DESCRIPTION
The Python script uses `||example.com$all`, which seems to blocking any domain containing `example.com`. In my opinion, this syntax is better:
```adblock
||example.com^$all
```
This is the syntax used in uBo’s own filter lists ([example](https://github.com/uBlockOrigin/uAssets/blob/master/filters/badware.txt#L1445)) and many other filter lists for completely blocking a domain.
Docs: https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#static-network-filtering