### PR TITLE
add pylint.org

### DIFF
--- a/data/seo_spam.txt
+++ b/data/seo_spam.txt
@@ -31,3 +31,4 @@
 *://ngontinh24.com/*
 *://nmstep.org/*
 *://juicycleanses.com/*
+*://pylint.org/*


### PR DESCRIPTION
It's not exacly SEO spam, but the website of an abandoned project, of which the active fork is https://github.com/PyCQA/pylint. pylint.org serves outdated documentation on a rather shady looking website.

Context:
https://github.com/PyCQA/pylint/issues/3659
https://github.com/PyCQA/pylint/issues/7384