### PR TITLE
github_copycats: add rat.dev

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -75,6 +75,7 @@
 *://codesti.com/*
 *://pythontechworld.com/*
 *://web.bluecomtech.com/*
+*://rat.dev/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
 ! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.


### PR DESCRIPTION
This domains seems to reverse-proxy into the up-to-date dataset, because it shows very recent interactions. Looks shady as fuck.


Proof: https://rat.dev/letsblockit/letsblockit/pull/412  vs https://github.com/letsblockit/letsblockit/pull/412