### PR TITLE
added gitnux.com

### DIFF
--- a/data/github_copycats.txt
+++ b/data/github_copycats.txt
@@ -80,6 +80,7 @@
 *://giterhub.com/*
 *://githubissues.com/*
 *://githubrecord.com/*
+*://gitnux.com/*
 ! github-wiki-see.page is a service that allows indexing of GitHub Wikis that GitHub blocks indexing of which is nearly all of them.
 ! At the moment, only about a couple thousand GitHub Wikis are permitted to be indexed out of about 420,000 in existence.
 ! Please visit https://github-wiki-see.page for a more thorough and/or updated explanation of the situation.


### PR DESCRIPTION
Added a new GitHub copycat `gitnux.com` which is frequently showing up as the first result in Google searches.