### PR TITLE
Fix google filter

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -47,7 +47,7 @@ def to_domain_hosts_filter(url):
     return f"0.0.0.0 {formated_url}"
 
 def to_google(url):
-    return f'google.*###rso .MjjYud a[href*="{regex_to_domain(url)}"]:upward(.MjjYud)'
+    return f'google.*###rso .TzHB6b a[href*="{regex_to_domain(url)}"]:upward(.TzHB6b)'
 
 def to_duckduckgo(url):
     return f'duckduckgo.com##.react-results--main > li:has(a[href*="{regex_to_domain(url)}"])'


### PR DESCRIPTION
Existing filter with `.MjjYud` causes google search results to be completely empty if any of the domains match at least one google search result.

Replacing `.MjjYud` with `.TzHB6b` works as intended.